### PR TITLE
Resolve crash for cookies with null expiry date. #16

### DIFF
--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -166,7 +166,9 @@ RCT_EXPORT_METHOD(
             [d setObject:c.name forKey:@"name"];
             [d setObject:c.domain forKey:@"domain"];
             [d setObject:c.path forKey:@"path"];
-            [d setObject:[self.formatter stringFromDate:c.expiresDate] forKey:@"expiresDate"];
+            if (c.expiresDate != NULL) {
+                [d setObject:[self.formatter stringFromDate:c.expiresDate] forKey:@"expiresDate"];
+            }
             [cookies setObject:d forKey:c.name];
         }
         resolve(cookies);


### PR DESCRIPTION
# Summary
Fix for #16 
Exception '*** -[__NSDictionaryM setObject:forKey:]: object cannot be nil (key: expiresDate)' was thrown while invoking get on target RNCookieManagerIOS

## Test Plan
Exception was thrown before null check was added, and now it's not.

### What's required for testing (prerequisites)?
* iOS
* there must be a cookie in the NSHTTPCookieStorage cookie store with a missing expiry date,

### What are the steps to reproduce (after prerequisites)?
 CookieManager.get must be called with useWebkit=false

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [  ✅] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
