### PR TITLE
fix(iOS): Handle optional keys in `set()` method and sync `get()` and `getAll()` method behavior (closes #15, #18)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,12 @@
-declare module "@react-native-community/cookies" {
+declare module '@react-native-community/cookies' {
   export interface Cookie {
     name: string;
     value: string;
-    domain: string;
     path: string;
-    origin: string;
-    version: string;
-    expiration: string;
+    domain?: string;
+    origin?: string;
+    version?: string;
+    expiration?: string;
   }
 
   export interface Cookies {
@@ -20,7 +20,7 @@ declare module "@react-native-community/cookies" {
 
     // iOS only.
     getAll(
-      useWebKit?: boolean
+      useWebKit?: boolean,
     ): Promise<{
       [key: string]: Cookie;
     }>;

--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -15,6 +15,13 @@
 static NSString * const NOT_AVAILABLE_ERROR_MESSAGE = @"WebKit/WebKit-Components are only available with iOS11 and higher!";
 static NSString * const INVALID_URL_MISSING_HTTP = @"Invalid URL: It may be missing a protocol (ex. http:// or https://).";
 
+static inline BOOL isEmpty(id value)
+{
+    return value == nil
+        || ([value respondsToSelector:@selector(length)] && [(NSData *)value length] == 0)
+        || ([value respondsToSelector:@selector(count)] && [(NSArray *)value count] == 0);
+}
+
 @implementation RNCookieManagerIOS
 
 - (instancetype)init
@@ -42,20 +49,28 @@ RCT_EXPORT_METHOD(
 {
     NSString *name = [RCTConvert NSString:props[@"name"]];
     NSString *value = [RCTConvert NSString:props[@"value"]];
+    NSString *path = [RCTConvert NSString:props[@"path"]];
     NSString *domain = [RCTConvert NSString:props[@"domain"]];
     NSString *origin = [RCTConvert NSString:props[@"origin"]];
-    NSString *path = [RCTConvert NSString:props[@"path"]];
     NSString *version = [RCTConvert NSString:props[@"version"]];
     NSDate *expiration = [RCTConvert NSDate:props[@"expiration"]];
 
     NSMutableDictionary *cookieProperties = [NSMutableDictionary dictionary];
     [cookieProperties setObject:name forKey:NSHTTPCookieName];
     [cookieProperties setObject:value forKey:NSHTTPCookieValue];
-    [cookieProperties setObject:domain forKey:NSHTTPCookieDomain];
-    [cookieProperties setObject:origin forKey:NSHTTPCookieOriginURL];
     [cookieProperties setObject:path forKey:NSHTTPCookiePath];
-    [cookieProperties setObject:version forKey:NSHTTPCookieVersion];
-    [cookieProperties setObject:expiration forKey:NSHTTPCookieExpires];
+    if (!isEmpty(domain)) {
+        [cookieProperties setObject:domain forKey:NSHTTPCookieDomain];
+    }
+    if (!isEmpty(origin)) {
+        [cookieProperties setObject:origin forKey:NSHTTPCookieOriginURL];
+    }
+    if (!isEmpty(version)) {
+         [cookieProperties setObject:version forKey:NSHTTPCookieVersion];
+    }
+    if (!isEmpty(expiration)) {
+         [cookieProperties setObject:expiration forKey:NSHTTPCookieExpires];
+    }
 
     NSHTTPCookie *cookie = [NSHTTPCookie cookieWithProperties:cookieProperties];
 
@@ -80,7 +95,7 @@ RCT_EXPORT_METHOD(setFromResponse:(NSURL *)url
     resolver:(RCTPromiseResolveBlock)resolve
     rejecter:(RCTPromiseRejectBlock)reject) {
     NSArray *cookies = [NSHTTPCookie cookiesWithResponseHeaderFields:@{@"Set-Cookie": value} forURL:url];
-    [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookies:cookies forURL:url mainDocumentURL:NULL];
+    [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookies:cookies forURL:url mainDocumentURL:nil];
     resolve(nil);
 }
 
@@ -104,30 +119,6 @@ RCT_EXPORT_METHOD(getFromResponse:(NSURL *)url
     }];
 }
 
--(NSString *)getDomainName:(NSURL *) url
-{
-    NSString *separator = @".";
-    NSInteger maxLength = 2;
-
-    NSURLComponents *components = [[NSURLComponents alloc]initWithURL:url resolvingAgainstBaseURL:FALSE];
-
-    if ([components.host isEqual: @""] || components.host == nil) {
-        return nil;
-    }
-
-    NSArray<NSString *> *separatedHost = [components.host componentsSeparatedByString:separator];
-    NSInteger count = [separatedHost count];
-    NSInteger endPosition = count;
-    NSInteger startPosition = count - maxLength;
-
-    NSMutableString *result = [[NSMutableString alloc]init];
-    for (NSUInteger i = startPosition; i != endPosition; i++) {
-        [result appendString:separator];
-        [result appendString:[separatedHost objectAtIndex:i]];
-    }
-    return result;
-}
-
 RCT_EXPORT_METHOD(
     get:(NSURL *) url
     useWebKit:(BOOL)useWebKit
@@ -137,7 +128,7 @@ RCT_EXPORT_METHOD(
     if (useWebKit) {
         if (@available(iOS 11.0, *)) {
             dispatch_async(dispatch_get_main_queue(), ^(){
-                NSString *topLevelDomain = [self getDomainName:url];
+                NSString *topLevelDomain = url.host;
 
                 if (topLevelDomain == nil) {
                     reject(@"", INVALID_URL_MISSING_HTTP, nil);
@@ -147,9 +138,9 @@ RCT_EXPORT_METHOD(
                 WKHTTPCookieStore *cookieStore = [[WKWebsiteDataStore defaultDataStore] httpCookieStore];
                 [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *allCookies) {
                     NSMutableDictionary *cookies = [NSMutableDictionary dictionary];
-                    for(NSHTTPCookie *currentCookie in allCookies) {
-                        if([currentCookie.domain containsString:topLevelDomain]) {
-                            [cookies setObject:currentCookie.value forKey:currentCookie.name];
+                    for (NSHTTPCookie *cookie in allCookies) {
+                        if ([cookie.domain containsString:topLevelDomain]) {
+                            [cookies setObject:[self createCookieData:cookie] forKey:cookie.name];
                         }
                     }
                     resolve(cookies);
@@ -160,16 +151,8 @@ RCT_EXPORT_METHOD(
         }
     } else {
         NSMutableDictionary *cookies = [NSMutableDictionary dictionary];
-        for (NSHTTPCookie *c in [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookiesForURL:url]) {
-            NSMutableDictionary *d = [NSMutableDictionary dictionary];
-            [d setObject:c.value forKey:@"value"];
-            [d setObject:c.name forKey:@"name"];
-            [d setObject:c.domain forKey:@"domain"];
-            [d setObject:c.path forKey:@"path"];
-            if (c.expiresDate != NULL) {
-                [d setObject:[self.formatter stringFromDate:c.expiresDate] forKey:@"expiresDate"];
-            }
-            [cookies setObject:d forKey:c.name];
+        for (NSHTTPCookie *cookie in [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookiesForURL:url]) {
+            [cookies setObject:[self createCookieData:cookie] forKey:cookie.name];
         }
         resolve(cookies);
     }
@@ -250,10 +233,14 @@ RCT_EXPORT_METHOD(
 -(NSDictionary *)createCookieData:(NSHTTPCookie *)cookie
 {
     NSMutableDictionary *cookieData = [NSMutableDictionary dictionary];
-    [cookieData setObject:cookie.value forKey:@"value"];
     [cookieData setObject:cookie.name forKey:@"name"];
-    [cookieData setObject:cookie.domain forKey:@"domain"];
+    [cookieData setObject:cookie.value forKey:@"value"];
     [cookieData setObject:cookie.path forKey:@"path"];
+    [cookieData setObject:cookie.domain forKey:@"domain"];
+    [cookieData setObject:[NSString stringWithFormat:@"%@", @(cookie.version)] forKey:@"version"];
+    if (!isEmpty(cookie.expiresDate)) {
+        [cookieData setObject:[self.formatter stringFromDate:cookie.expiresDate] forKey:@"expiration"];
+    }
     return cookieData;
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

This PR properly handles optional cookies keys (`origin`, `version` and `expiration`) in the `set()` method.

It also fixes the response for the `get()` and `getAll()` methods. The results are now consistent with and without the `useWebKit` option.

Closes #15, #18.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

An iOS device/simulator.

### What are the steps to reproduce (after prerequisites)?

#### `set()` method

```js
await CookieManager.set({
  name: 'foo',
  value: 'foo',
  path: '/',
  domain: 'google.com'
});

// With `useWebKit` enabled
await CookieManager.set({
  name: 'foo',
  value: 'foo',
  path: '/',
  domain: 'google.com'
}, true);
```

#### `get()` method

```js
await CookieManager.set({
  name: 'foo',
  value: 'foo',
  path: '/',
  domain: 'google.com'
});
await CookieManager.set({
  name: 'foo',
  value: 'foo',
  path: '/',
  domain: '.google.com' // See the dot here
});

console.log(await CookieManager.get('https://google.com'));

// With `useWebKit` enabled
console.log(await CookieManager.get('https://google.com', true));
```

#### `getAll()` method

```js
await CookieManager.set({
  name: 'foo',
  value: 'foo',
  path: '/',
  domain: 'google.com',
  version: '1',
   expiration: '2020-01-01T12:30:00.00-00:00'
});
await CookieManager.set({
  name: 'foo',
  value: 'foo',
  path: '/',
  domain: '.google.com'
});

console.log(await CookieManager.getAll());

// With `useWebKit` enabled
console.log(await CookieManager.getAll(true));
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
