### PR TITLE
Recommend pod-install for setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Currently lacking support for Windows, macOS, and web. Support for these platfor
 yarn add @react-native-community/cookies
 ```
 
+Then link the native iOS package
+
+```
+npx pod-install
+```
 
 ## Setup (React Native < 0.60.0)
 


### PR DESCRIPTION

# Summary

We've been recommending devs use `npx pod-install` since it will attempt to install CocoaPods CLI if it's not available on the computer (cite [React Navigation setup guide](https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project)). This has proved very useful for Expo users who are now migrating to the bare workflow and want to use community packages in their projects.

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
