### PR TITLE
Fixed cookies getting restored on restart

### DIFF
--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -172,6 +172,7 @@ RCT_EXPORT_METHOD(
         for (NSHTTPCookie *c in cookieStorage.cookies) {
             [cookieStorage deleteCookie:c];
         }
+        [[NSUserDefaults standardUserDefaults] synchronize];
         resolve(@(YES));
     }
 }


### PR DESCRIPTION
When calling .clearAll() and immediately restarting, or as a part of `componentDidMount()` then it wouldn't take immediate effect. This is likely due to, as this StackOverflow comment suggests, that you need to synchronize the cookie jar to disk first:
https://stackoverflow.com/questions/4471629/how-to-delete-all-cookies-of-uiwebview#comment14443726_4471747
Or seen in more comments here:
https://stackoverflow.com/questions/9647931/nsuserdefaults-synchronize-method/9647965#9647965

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
