### PR TITLE
fix: Proposed fix for adding useWebKit support to getFromResponse/set…

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cookies/CookieManagerModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cookies/CookieManagerModule.java
@@ -76,7 +76,7 @@ public class CookieManagerModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setFromResponse(String url, String cookie, final Promise promise) {
+    public void setFromResponse(String url, String cookie, Boolean useWebKit, final Promise promise) {
         if (cookie == null) {
             promise.reject(new Exception(INVALID_COOKIE_VALUES));
             return;
@@ -96,7 +96,7 @@ public class CookieManagerModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void getFromResponse(String url, Promise promise) throws URISyntaxException, IOException {
+    public void getFromResponse(String url, Boolean useWebkit, Promise promise) throws URISyntaxException, IOException {
         promise.resolve(url);
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,10 +16,10 @@ declare module '@react-native-community/cookies' {
 
   export interface CookieManagerStatic {
     set(url: string, cookie: Cookie, useWebKit?: boolean): Promise<boolean>;
-    setFromResponse(url: string, cookie: string): Promise<boolean>;
+    setFromResponse(url: string, cookie: string, useWebKit?: boolean): Promise<boolean>;
 
     get(url: string, useWebKit?: boolean): Promise<Cookies>;
-    getFromResponse(url: string): Promise<Cookies>;
+    getFromResponse(url: string, useWebKit?: boolean): Promise<Cookies>;
 
     clearAll(useWebKit?: boolean): Promise<boolean>;
 

--- a/index.js
+++ b/index.js
@@ -39,6 +39,10 @@ module.exports = {
   get: (url, useWebKit = false) => CookieManager.get(url, useWebKit),
   set: (url, cookie, useWebKit = false) =>
     CookieManager.set(url, cookie, useWebKit),
+  setFromResponse: (url, cookie, useWebKit = false) =>
+    CookieManager.setFromResponse(url, cookie, useWebKit),
+  getFromResponse: (url, useWebKit = false) =>
+    CookieManager.getFromResponse(url, useWebKit),
   clearByName: (url, name, useWebKit = false) =>
     CookieManager.clearByName(url, name, useWebKit),
   flush: async () => {

--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -78,32 +78,67 @@ RCT_EXPORT_METHOD(
 RCT_EXPORT_METHOD(
     setFromResponse:(NSURL *)url
     cookie:(NSString *)cookie
+    useWebKit:(BOOL)useWebKit
     resolver:(RCTPromiseResolveBlock)resolve
-    rejecter:(RCTPromiseRejectBlock)reject) {
-    
+    rejecter:(RCTPromiseRejectBlock)reject)
+{
     NSArray *cookies = [NSHTTPCookie cookiesWithResponseHeaderFields:@{@"Set-Cookie": cookie} forURL:url];
-    [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookies:cookies forURL:url mainDocumentURL:nil];
-    resolve(@(YES));
+    if (useWebKit) {
+        if (@available(iOS 11.0, *)) {
+            dispatch_async(dispatch_get_main_queue(), ^(){
+                WKHTTPCookieStore *cookieStore = [[WKWebsiteDataStore defaultDataStore] httpCookieStore];
+                for (NSHTTPCookie* cookie in cookies)
+                {
+                    [cookieStore setCookie:cookie completionHandler:nil];
+                }
+                resolve(@(YES));
+            });
+        } else {
+            reject(@"", NOT_AVAILABLE_ERROR_MESSAGE, nil);
+        }
+    } else {
+        [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookies:cookies forURL:url mainDocumentURL:nil];
+        resolve(@(YES));
+    }
 }
 
 RCT_EXPORT_METHOD(
     getFromResponse:(NSURL *)url
+    useWebKit:(BOOL)useWebKit
     resolver:(RCTPromiseResolveBlock)resolve
-    rejecter:(RCTPromiseRejectBlock)reject) {
+    rejecter:(RCTPromiseRejectBlock)reject)
+{
     NSURLRequest *request = [NSURLRequest requestWithURL:url];
     [NSURLConnection sendAsynchronousRequest:request  queue:[[NSOperationQueue alloc] init]
                            completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
 
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
         NSArray *cookies = [NSHTTPCookie cookiesWithResponseHeaderFields:httpResponse.allHeaderFields forURL:response.URL];
-        NSMutableDictionary *dics = [NSMutableDictionary dictionary];
+        if (useWebKit) {
+            if (@available(iOS 11.0, *)) {
+                dispatch_async(dispatch_get_main_queue(), ^(){
+                    NSMutableDictionary *dics = [NSMutableDictionary dictionary];
+                    WKHTTPCookieStore *cookieStore = [[WKWebsiteDataStore defaultDataStore] httpCookieStore];
+                    for (int i = 0; i < cookies.count; i++) {
+                        NSHTTPCookie *cookie = [cookies objectAtIndex:i];
+                        [dics setObject:cookie.value forKey:cookie.name];
+                        [cookieStore setCookie:cookie completionHandler:nil];
+                    }
+                    resolve(dics);
+                });
+            } else {
+                reject(@"", NOT_AVAILABLE_ERROR_MESSAGE, nil);
+            }
+        } else {
+            NSMutableDictionary *dics = [NSMutableDictionary dictionary];
+            for (int i = 0; i < cookies.count; i++) {
+                NSHTTPCookie *cookie = [cookies objectAtIndex:i];
+                [dics setObject:cookie.value forKey:cookie.name];
+                [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookie:cookie];
+            }
+            resolve(dics);
 
-        for (int i = 0; i < cookies.count; i++) {
-            NSHTTPCookie *cookie = [cookies objectAtIndex:i];
-            [dics setObject:cookie.value forKey:cookie.name];
-            [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookie:cookie];
         }
-        resolve(dics);
     }];
 }
 


### PR DESCRIPTION
# Proposed fix for #72 useWebKit option on setFromResponse/getFromResponse

* Should resolve issues with getFromResponse/setFromResponse not supporting WK cookie store.
* Should not interfere with current calls to those methods by stubbing useWebKit as optional in index.js

## Test Plan

setFromResponse is working for me in live code, getFromResponse is untested.

Apologies, this is a draft PR I have no test plan.

### What's required for testing (prerequisites)?

An url that produces cookies for getFromResponse

### What are the steps to reproduce (after prerequisites)?

Check to see if getFromResponse successfully sets cookies in WKHTTPCookieStore.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅   |
| Android |    ✅    |

## Checklist

setFromResponse is tested in the wild, but getFromResponse is not, so no X in that box.
There is no CHANGELOG.md.

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
