### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/react-native-cookies.podspec
+++ b/react-native-cookies.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.platform            = :ios, "7.0"
   s.preserve_paths      = "*.framework"
   s.source_files        = "ios/**/*.{h,m}"
-  s.dependency "React"
+  s.dependency "React-Core"
 end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Latest Xcode 12 fails to build while without a module to depend on `React-Core` directly hence this change is necessary for all native modules on iOS. This change requires React Native 0.60.2 or newer. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116

## Test Plan

Use this branch to install with an app running on Xcode 12.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
