### PR TITLE
72: Added useWebKit support for getFromResponse and setFromResponse.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Cookie Manager for React Native
 This module was ported from [joeferraro/react-native-cookies](https://github.com/joeferraro/react-native-cookies). This would not exist without the work of the original author, [Joe Ferraro](https://github.com/joeferraro).
 
 ## Important notices & Breaking Changes
+
 - **v6.0.0**: Package name updated to `@react-native-cookies/cookies`.
 - **v5.0.0**: Peer Dependency of >= React Native 0.60.2
 - **v4.0.0**: Android SDK version bumpted to 21
@@ -131,13 +132,15 @@ To use WebKit-Support, you should be able to simply make advantage of the react-
 
 To use this _CookieManager_ with WebKit-Support we extended the interface with the attribute `useWebKit` (a boolean value, default: `FALSE`) for the following methods:
 
-| Method      | WebKit-Support | Method-Signature                                                         |
-| ----------- | -------------- | ------------------------------------------------------------------------ |
-| getAll      | Yes            | `CookieManager.getAll(useWebKit:boolean)`                                |
-| clearAll    | Yes            | `CookieManager.clearAll(useWebKit:boolean)`                              |
-| clearByName | Yes            | `CookieManager.clearByName(url:string, name: string, useWebKit:boolean)` |
-| get         | Yes            | `CookieManager.get(url:string, useWebKit:boolean)`                       |
-| set         | Yes            | `CookieManager.set(url:string, cookie:object, useWebKit:boolean)`        |
+| Method          | WebKit-Support | Method-Signature                                                              |
+| --------------- | -------------- | ----------------------------------------------------------------------------- |
+| getAll          | Yes            | `CookieManager.getAll(useWebKit:boolean)`                                     |
+| clearAll        | Yes            | `CookieManager.clearAll(useWebKit:boolean)`                                   |
+| clearByName     | Yes            | `CookieManager.clearByName(url:string, name: string, useWebKit:boolean)`      |
+| get             | Yes            | `CookieManager.get(url:string, useWebKit:boolean)`                            |
+| getFromResponse | Yes            | `CookieManager.getFromResponse(url:string, useWebKit:boolean)`                |
+| set             | Yes            | `CookieManager.set(url:string, cookie:object, useWebKit:boolean)`             |
+| setFromResponse | Yes            | `CookieManager.setFromResponse(url:string, cookie:object, useWebKit:boolean)` |
 
 ##### Usage
 
@@ -170,6 +173,12 @@ CookieManager.get('http://example.com', useWebKit)
 		console.log('CookieManager.get from webkit-view =>', cookies);
 	});
 
+// Get cookies as a request header string
+CookieManager.getFromResponse('http://example.com', useWebKit)
+	.then((cookies) => {
+		console.log('CookieManager.getFromResponse from webkit-view =>', cookies);
+	});
+
 // set a cookie
 const newCookie: = {
 	name: 'myCookie',
@@ -180,8 +189,21 @@ const newCookie: = {
 	expires: '2015-05-30T12:30:00.00-05:00'
 };
 
+// set a cookie
 CookieManager.set('http://example.com', newCookie, useWebKit)
 	.then((res) => {
 		console.log('CookieManager.set from webkit-view =>', res);
 	});
+
+// Set cookies from a response header
+// This allows you to put the full string provided by a server's Set-Cookie
+// response header directly into the cookie store.
+CookieManager.setFromResponse(
+  'http://example.com',
+  'user_session=abcdefg; path=/; expires=Thu, 1 Jan 2030 00:00:00 -0000; secure; HttpOnly',
+  useWebKit)
+    .then((success) => {
+      console.log('CookieManager.setFromResponse from webkit-view =>', success);
+    });
+
 ```

--- a/android/src/main/java/com/reactnativecommunity/cookies/CookieManagerModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cookies/CookieManagerModule.java
@@ -76,7 +76,7 @@ public class CookieManagerModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setFromResponse(String url, String cookie, final Promise promise) {
+    public void setFromResponse(String url, String cookie, Boolean useWebKit, final Promise promise) {
         if (cookie == null) {
             promise.reject(new Exception(INVALID_COOKIE_VALUES));
             return;
@@ -96,7 +96,7 @@ public class CookieManagerModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void getFromResponse(String url, Promise promise) throws URISyntaxException, IOException {
+    public void getFromResponse(String url, Boolean useWebKit, Promise promise) throws URISyntaxException, IOException {
         promise.resolve(url);
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,10 +16,10 @@ declare module '@react-native-cookies/cookies' {
 
   export interface CookieManagerStatic {
     set(url: string, cookie: Cookie, useWebKit?: boolean): Promise<boolean>;
-    setFromResponse(url: string, cookie: string): Promise<boolean>;
+    setFromResponse(url: string, cookie: string, useWebKit?: boolean): Promise<boolean>;
 
     get(url: string, useWebKit?: boolean): Promise<Cookies>;
-    getFromResponse(url: string): Promise<Cookies>;
+    getFromResponse(url: string, useWebKit?: boolean): Promise<Cookies>;
 
     clearAll(useWebKit?: boolean): Promise<boolean>;
 

--- a/index.js
+++ b/index.js
@@ -31,14 +31,16 @@ if (Platform.OS === 'ios') {
   );
 }
 
-const functions = ['setFromResponse', 'getFromResponse'];
-
 module.exports = {
   getAll: (useWebKit = false) => CookieManager.getAll(useWebKit),
   clearAll: (useWebKit = false) => CookieManager.clearAll(useWebKit),
   get: (url, useWebKit = false) => CookieManager.get(url, useWebKit),
+  getFromResponse: (url, useWebKit = false) =>
+	CookieManager.getFromResponse(url, useWebKit),
   set: (url, cookie, useWebKit = false) =>
     CookieManager.set(url, cookie, useWebKit),
+  setFromResponse: (url, cookie, useWebKit = false) =>
+  	CookieManager.setFromResponse(url, cookie, useWebKit),
   clearByName: (url, name, useWebKit = false) =>
     CookieManager.clearByName(url, name, useWebKit),
   flush: async () => {
@@ -47,7 +49,3 @@ module.exports = {
     }
   },
 };
-
-for (var i = 0; i < functions.length; i++) {
-  module.exports[functions[i]] = CookieManager[functions[i]];
-}


### PR DESCRIPTION
# Summary

FYI, this code from an existing PR (https://github.com/react-native-cookies/cookies/pull/74) with README updated and branched from the latest code in master.

Fixes #72 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Checklist:

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in README.md
- [ ] I mentioned this change in CHANGELOG.md
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (example/App.js)