### PR TITLE
Modified how webkit cookies are deleted in the clearAll method

### DIFF
--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -153,7 +153,8 @@ RCT_EXPORT_METHOD(
             dispatch_async(dispatch_get_main_queue(), ^(){
                 [[WKWebsiteDataStore defaultDataStore] fetchDataRecordsOfTypes:WKWebsiteDataStore.allWebsiteDataTypes
                                                              completionHandler:^(NSArray<WKWebsiteDataRecord *> * _Nonnull records) {
-                    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:WKWebsiteDataStore.allWebsiteDataTypes
+                    NSSet *cookieDataType = [NSSet setWithArray:@[ WKWebsiteDataTypeCookies ]];
+                    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:cookieDataType
                                                               forDataRecords:records
                                                            completionHandler:^{
                                                               resolve(@(YES));

--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -151,14 +151,15 @@ RCT_EXPORT_METHOD(
     if (useWebKit) {
         if (@available(iOS 11.0, *)) {
             dispatch_async(dispatch_get_main_queue(), ^(){
-                // https://stackoverflow.com/questions/46465070/how-to-delete-cookies-from-wkhttpcookiestore#answer-47928399
-                NSSet *websiteDataTypes = [NSSet setWithArray:@[WKWebsiteDataTypeCookies]];
-                NSDate *dateFrom = [NSDate dateWithTimeIntervalSince1970:0];
-                [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:websiteDataTypes
-                                                        modifiedSince:dateFrom
-                                                        completionHandler:^() {
-                                                            resolve(@(YES));
-                                                        }];
+                [[WKWebsiteDataStore defaultDataStore] fetchDataRecordsOfTypes:WKWebsiteDataStore.allWebsiteDataTypes
+                                                             completionHandler:^(NSArray<WKWebsiteDataRecord *> * _Nonnull records) {
+                    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:WKWebsiteDataStore.allWebsiteDataTypes
+                                                              forDataRecords:records
+                                                           completionHandler:^{
+                                                              resolve(@(YES));
+                                                           }
+                    ];
+                }];
             });
         } else {
             reject(@"", NOT_AVAILABLE_ERROR_MESSAGE, nil);

--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -151,7 +151,8 @@ RCT_EXPORT_METHOD(
     if (useWebKit) {
         if (@available(iOS 11.0, *)) {
             dispatch_async(dispatch_get_main_queue(), ^(){
-                [[WKWebsiteDataStore defaultDataStore] fetchDataRecordsOfTypes:WKWebsiteDataStore.allWebsiteDataTypes
+                NSSet *dataTypesToRetrieve = [NSSet setWithArray:@[ WKWebsiteDataTypeCookies ]];
+                [[WKWebsiteDataStore defaultDataStore] fetchDataRecordsOfTypes:dataTypesToRetrieve
                                                              completionHandler:^(NSArray<WKWebsiteDataRecord *> * _Nonnull records) {
                     NSSet *cookieDataType = [NSSet setWithArray:@[ WKWebsiteDataTypeCookies ]];
                     [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:cookieDataType


### PR DESCRIPTION
Previous implementation did not always delete all webkit cookies in iOS 15 and later.