### PR TITLE
Added WebStorage Data Deletion for ClearAll

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cookies/CookieManagerModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cookies/CookieManagerModule.java
@@ -12,6 +12,7 @@ import android.util.Log;
 import android.webkit.CookieManager;
 import android.webkit.CookieSyncManager;
 import android.webkit.ValueCallback;
+import android.webkit.WebStorage;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
@@ -165,6 +166,7 @@ public class CookieManagerModule extends ReactContextBaseJavaModule {
                 });
                 cookieManager.flush();
             }
+            WebStorage.getInstance().deleteAllData();
         } catch (Exception e) {
             promise.reject(e);
         }


### PR DESCRIPTION
In some cases, ClearAll with CookieManager does not work. We have faced a situation where Mircosoft Azure Login in WebView does not get logout properly. we were using  
` CookieManager.clearAll(true).then(() => {
                setTimeout(() => NavigationUtil.resetAndNavigateToMainLogin(), 5000);
 });`
it wasnt enough. it does not get logout properly. it has caches. so we had to write natively this method in Java
` WebStorage.getInstance().deleteAllData();`