### PR TITLE
feat(android): 🌟 add support for React Native 0.73

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "com.reactnativecommunity.cookies"
     compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
     buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
     defaultConfig {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.reactnativecommunity.cookies" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
# Overview
Starting from React Native v0.73 , all libraries will need to be updated with namespace due to the upgrade to AGP 8
https://github.com/react-native-community/discussions-and-proposals/issues/671

OS | Implemented
-- | --
iOS | ❌
Android | ✅

# Test Plan

I tested the changes on RN 0.71.11 and everything works!