### PR TITLE
Fix android domain dot prefix bug

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cookies/CookieManagerModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cookies/CookieManagerModule.java
@@ -244,8 +244,6 @@ public class CookieManagerModule extends ReactContextBaseJavaModule {
             }
 
             cookieBuilder.setDomain(domain);
-        } else {
-            cookieBuilder.setDomain(topLevelDomain);
         }
 
         // unlike iOS, Android will handle no path gracefully and assume "/""


### PR DESCRIPTION
### What's wrong?

> [!IMPORTANT]
> Currently, there is no way to set a cookie without a `.` prefix which can lead to buggy behavior with some sites.

This PR fixes that, by allowing cookies to be set without a domain and instead inferred from the url. `Domain` is allowed as an optional value in the [Android CookieManager docs](https://developer.android.com/reference/android/webkit/CookieManager#setCookie(java.lang.String,%20java.lang.String,%20android.webkit.ValueCallback%3Cjava.lang.Boolean%3E)) when setting a cookie.

Example usage of `Cookiemanager.set` which should result in a `.` domain prefix vs not:

```ts
// Setting a cookie like this should result in a `.` prefix in chrome dev tools
// This indicates it include sub-domains
CookieManager.set('www.example.domain.com', {
  name: 'Foo',
  value: 'Bar',
  domain: 'example.domain.com', // or '.example.domain.com'
});
// Cookie in chrome dev tools correctly results in: '.example.domain.com' 
```
 
```ts
// Setting a cookie like this should NOT result in a `.` prefix in chrome dev tools
CookieManager.set('www.example.domain.com', {
  name: 'Foo',
  value: 'Bar',
  // no domain specified
});
// Currently results in: '.example.domain.com'
// After PR results in: 'example.domain.com'
```

This proposed change removes `topLevelDomain` as a fallback value when `domain` is missing. This indirectly allows setting a cookie without a `.` prefix in android, more info [about the leading dot](https://stackoverflow.com/questions/9618217/what-does-the-dot-prefix-in-the-cookie-domain-mean/44244493#44244493) and [how the dot infers hostOnly](https://github.com/postmanlabs/postman-app-support/issues/7901#issuecomment-597453496).

### Why is this an issue?

> [!IMPORTANT]
> Currently, a cookie `Foo` can be duplicated on android because of the `.` domain prefix and there is no way to set a domain without a `.` prefix via the react-native-cookies library

For me, this caused a re-direct loop in one of our webviews because the site was only looking at the original cookie value and not the duplicated cookie value which was set by the HTTP response. I imagine the buggy behavior could manifest in different ways as well.

### How to reproduce? 

1) Set a `Foo=Bar` cookie via `CookieManager.set()`
2) Set a `Foo=FooBar` cookie via [Set-Cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#syntax) response header in a `Webview` on android.
3) The result is two cookies with the same name, but different domains which [are both valid cookies](https://stackoverflow.com/a/20884869/6171839) according to [RFC 6265](https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.3). 

Additionally, you can quickly verify that this is possible by simply creating two cookies in chrome dev tools.
![image](https://github.com/react-native-cookies/cookies/assets/14024977/02748a0c-41a7-4453-86e3-1863f1454bb6)
