### PR TITLE
Add Privacy Manifest

### DIFF
--- a/ios/PrivacyInfo.xcprivacy
+++ b/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/ios/RNCookieManagerIOS.xcodeproj/project.pbxproj
+++ b/ios/RNCookieManagerIOS.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		6CDA467A38779CEFE54AF652 /* Pods-RNCookieManagerIOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNCookieManagerIOS.debug.xcconfig"; path = "Target Support Files/Pods-RNCookieManagerIOS/Pods-RNCookieManagerIOS.debug.xcconfig"; sourceTree = "<group>"; };
 		7A3E91C9DB889DAEAB299FB5 /* Pods_RNCookieManagerIOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RNCookieManagerIOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC0CCEFD0D5DDBC08A3F9FDB /* Pods-RNCookieManagerIOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNCookieManagerIOS.release.xcconfig"; path = "Target Support Files/Pods-RNCookieManagerIOS/Pods-RNCookieManagerIOS.release.xcconfig"; sourceTree = "<group>"; };
+		F29511B12BBF92D200DF6087 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,6 +56,7 @@
 		1BD725CD1CF7795C005DBD79 = {
 			isa = PBXGroup;
 			children = (
+				F29511B12BBF92D200DF6087 /* PrivacyInfo.xcprivacy */,
 				1BD725FF1CF77DD1005DBD79 /* RNCookieManagerIOS */,
 				1BD725DB1CF77A8B005DBD79 /* Products */,
 				71405C5FF90D2ACAB4F0366B /* Pods */,

--- a/react-native-cookies.podspec
+++ b/react-native-cookies.podspec
@@ -15,4 +15,7 @@ Pod::Spec.new do |s|
   s.preserve_paths      = "*.framework"
   s.source_files        = "ios/**/*.{h,m}"
   s.dependency "React-Core"
+  s.resource_bundles = {
+    'RNCookiePrivacyInfo' => ['ios/PrivacyInfo.xcprivacy'],
+  }
 end


### PR DESCRIPTION
Add Privacy Manifest for NSUserDefaults usage.

I'm not sure if adding a Privacy Manifest is the right approach for this library because I don't believe (or I'm not certain) this library collects any user information through NSUserDefaults.

If you have any ideas (or if I'm missing something), please comment below.


<br/>
<br/>

p.s.)

If you archive your project and then generate Privacy Report as PDF, you can see RNCookiePrivacyInfo.bundle like below :

![Screenshot 2024-04-05 at 5 59 56 PM](https://github.com/react-native-cookies/cookies/assets/47589599/2a03aea4-2553-4d8f-b698-1a1f0c736b93)


