### PR TITLE
Removing the deprecated jcenter()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.5.3'
@@ -67,7 +66,6 @@ repositories {
         url "$rootDir/../node_modules/jsc-android/dist"
     }
     google()
-    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
Android 14 upgrade is currently blocked due to having deprecated jcenter() method. 